### PR TITLE
Fix support for non-b64 data URLs

### DIFF
--- a/data_uri_parser/__init__.py
+++ b/data_uri_parser/__init__.py
@@ -114,5 +114,5 @@ class DataURI(str):
         if match.group("base64"):
             data = b64decode(match.group("data"))
         else:
-            data = urllib.unquote(match.group("data"))
+            data = urllib.parse.unquote(match.group("data"))
         return mimetype, charset, bool(match.group("base64")), data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-uri-parser"
-version = "0.1.4"
+version = "0.1.5"
 readme = "README.md"
 license = "MIT"
 description = "A Pythonic data uri parser"

--- a/tests/test_data_uri_parser.py
+++ b/tests/test_data_uri_parser.py
@@ -34,6 +34,14 @@ def dummy_content_and_data_uri():
 
 
 @fixture(scope="function")
+def dummy_content_and_data_uri_non_b64():
+    return (
+        "foo bar:1234,5678",
+        "data:text/plain;charset=UTF-8,foo%20bar:1234,5678",
+    )
+
+
+@fixture(scope="function")
 def dummy_response_object():
     class TestResponse:
         def __init__(self, content_type, content):
@@ -71,6 +79,16 @@ class TestDataURI:
         assert data_uri.mimetype == "application/pdf"
         assert data_uri.is_base64
         assert type(data_uri.data) == bytes
+        assert data_uri.data == content
+
+    def test_from_string_to_data_uri_non_b64(self, dummy_content_and_data_uri_non_b64):
+        content, dummy_data_uri = dummy_content_and_data_uri_non_b64
+        data_uri = DataURI(dummy_data_uri)
+
+        assert type(data_uri) == DataURI
+        assert data_uri.mimetype == "text/plain"
+        assert not data_uri.is_base64
+        assert type(data_uri.data) == str
         assert data_uri.data == content
 
     def test_from_mimetype_and_data_to_data_uri(self):


### PR DESCRIPTION
`urllib.unquote` apparently moved to `urllib.parse` at some point, but we didn't have any test cases covering its use, so missed it.

Here we also add a test case for a non-b64, plaintext data URL with a charset.