### PR TITLE
Support content-type whitespace

### DIFF
--- a/data_uri_parser/__init__.py
+++ b/data_uri_parser/__init__.py
@@ -15,7 +15,7 @@ _CHARSET_RE = re.compile("^{}$".format(CHARSET_REGEX))
 DATA_URI_REGEX = (
     r"data:"
     + r"(?P<mimetype>{})?".format(MIMETYPE_REGEX)
-    + r"(?:\;charset\=(?P<charset>{}))?".format(CHARSET_REGEX)
+    + r"(?:\;(?:\s*)charset\=(?P<charset>{}))?".format(CHARSET_REGEX)
     + r"(?P<base64>\;base64)?"
     + r",(?P<data>.*)"
 )
@@ -23,7 +23,7 @@ _DATA_URI_RE = re.compile(r"^{}$".format(DATA_URI_REGEX), re.DOTALL)
 
 CONTEXT_TYPE_REGEX = r"(?P<mimetype>{})?".format(
     MIMETYPE_REGEX
-) + r"(?:\;charset\=(?P<charset>{}))?".format(CHARSET_REGEX)
+) + r"(?:\;(?:\s*)?charset\=(?P<charset>{}))?".format(CHARSET_REGEX)
 
 _CONTEXT_URI_RE = re.compile(r"^{}$".format(CONTEXT_TYPE_REGEX), re.DOTALL)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-uri-parser"
-version = "0.1.5"
+version = "0.1.6"
 readme = "README.md"
 license = "MIT"
 description = "A Pythonic data uri parser"

--- a/tests/test_data_uri_parser.py
+++ b/tests/test_data_uri_parser.py
@@ -42,6 +42,14 @@ def dummy_content_and_data_uri_non_b64():
 
 
 @fixture(scope="function")
+def dummy_content_and_data_uri_non_b64_with_whitespace():
+    return (
+        "foo bar:1234,5678",
+        "data:text/plain; charset=UTF-8,foo%20bar:1234,5678",
+    )
+
+
+@fixture(scope="function")
 def dummy_response_object():
     class TestResponse:
         def __init__(self, content_type, content):
@@ -83,6 +91,18 @@ class TestDataURI:
 
     def test_from_string_to_data_uri_non_b64(self, dummy_content_and_data_uri_non_b64):
         content, dummy_data_uri = dummy_content_and_data_uri_non_b64
+        data_uri = DataURI(dummy_data_uri)
+
+        assert type(data_uri) == DataURI
+        assert data_uri.mimetype == "text/plain"
+        assert not data_uri.is_base64
+        assert type(data_uri.data) == str
+        assert data_uri.data == content
+
+    def test_from_string_to_data_uri_non_b64_with_whitespace(
+        self, dummy_content_and_data_uri_non_b64_with_whitespace
+    ):
+        content, dummy_data_uri = dummy_content_and_data_uri_non_b64_with_whitespace
         data_uri = DataURI(dummy_data_uri)
 
         assert type(data_uri) == DataURI


### PR DESCRIPTION
Allow whitespace in content type definition. This is apparently a perfectly valid data URI.

See https://sentry.io/organizations/unmade/issues/1620905020/?project=277671&referrer=slack