### PR TITLE
Fix/dependabot pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,6 @@ updates:
     day: sunday
     time: "01:00"
   open-pull-requests-limit: 99
+  insecure-external-code-execution: allow
   registries:
   - python-index-ddnwizwidpwdz-cloudfront-net

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-uri-parser"
-version = "0.1.6"
+version = "0.1.7"
 readme = "README.md"
 license = "MIT"
 description = "A Pythonic data uri parser"


### PR DESCRIPTION
### Why

At the moment we are not getting any updates for our python dependencies in any repo. Package managers with the package-ecosystem values such as pip may execute external code in the manifest as part of the version update process. This might allow a compromised package to steal credentials or gain access to configured registries.

Dependabot automatically prevents this behavior and stop updates during the checking process. We need to override this setting in order to get pip updates.

You can check the error here: https://github.com/unmadeworks/data_uri_parser/network/updates

### What

- set `insecure-external-code-execution` to `allow`